### PR TITLE
Fix UI bug: Separate data view and edit actions

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -188,240 +188,37 @@
 
                     <!-- Applications List -->
                     <div id="projects-container" class="space-y-4">
-                        <!-- Application 1 -->
-                        <a href="project-unified.html?edit=001" class="block bg-white/70 backdrop-blur-sm rounded-xl border border-notion-gray-200/60 shadow-notion hover:shadow-notion-hover transition-all duration-300 p-6 group cursor-pointer">
-                            <div class="flex items-start justify-between">
-                                <div class="flex items-start space-x-4 flex-1">
-                                    <div class="w-12 h-12 bg-gradient-to-br from-blue-400 to-blue-600 rounded-xl flex items-center justify-center text-white font-semibold text-lg">
-                                        田
-                                    </div>
-                                    <div class="flex-1">
-                                        <div class="flex items-center space-x-3 mb-2">
-                                            <h3 class="text-lg font-semibold text-notion-gray-800">田中太郎</h3>
-                                            <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-orange-100 text-orange-800 border border-orange-200">
-                                                審査中
-                                            </span>
-                                        </div>
-                                        <div class="grid grid-cols-2 md:grid-cols-5 gap-4 text-sm text-notion-gray-600">
-                                            <div>
-                                                <div class="text-xs text-notion-gray-500 mb-1">傷病名</div>
-                                                <div class="font-medium">うつ病</div>
-                                            </div>
-                                            <div>
-                                                <div class="text-xs text-notion-gray-500 mb-1">年金種類</div>
-                                                <div class="font-medium">厚生年金</div>
-                                            </div>
-                                            <div>
-                                                <div class="text-xs text-notion-gray-500 mb-1">初診日</div>
-                                                <div class="font-medium">2023年5月10日</div>
-                                            </div>
-                                            <div>
-                                                <div class="text-xs text-notion-gray-500 mb-1">家族構成</div>
-                                                <div class="font-medium">配偶者有・子1名</div>
-                                            </div>
-                                            <div>
-                                                <div class="text-xs text-notion-gray-500 mb-1">見込み収益</div>
-                                                <div class="font-medium">300,000円</div>
-                                            </div>
-                                        </div>
-                                        <div class="flex items-center mt-3 text-xs text-notion-gray-500">
-                                            <span>申請日: 2024年1月15日</span>
-                                            <span class="mx-2">•</span>
-                                            <span>担当: 佐藤花子</span>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="flex items-center space-x-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
-                                    <div class="p-2 text-notion-gray-500 hover:text-notion-gray-700 hover:bg-notion-gray-100 rounded-lg transition-all duration-200">
-                                        <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-                                            <path d="M10 12a2 2 0 100-4 2 2 0 000 4z"/>
-                                            <path fill-rule="evenodd" d="M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z" clip-rule="evenodd"/>
-                                        </svg>
-                                    </div>
-                                    <div class="p-2 text-notion-gray-500 hover:text-notion-gray-700 hover:bg-notion-gray-100 rounded-lg transition-all duration-200">
-                                        <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-                                            <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"/>
-                                        </svg>
-                                    </div>
-                                </div>
-                            </div>
-                        </a>
-
-                        <!-- Application 2 -->
-                        <a href="project-unified.html?edit=002" class="block bg-white/70 backdrop-blur-sm rounded-xl border border-notion-gray-200/60 shadow-notion hover:shadow-notion-hover transition-all duration-300 p-6 group cursor-pointer">
-                            <div class="flex items-start justify-between">
-                                <div class="flex items-start space-x-4 flex-1">
-                                    <div class="w-12 h-12 bg-gradient-to-br from-pink-400 to-pink-600 rounded-xl flex items-center justify-center text-white font-semibold text-lg">
-                                        山
-                                    </div>
-                                    <div class="flex-1">
-                                        <div class="flex items-center space-x-3 mb-2">
-                                            <h3 class="text-lg font-semibold text-notion-gray-800">山田花子</h3>
-                                            <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800 border border-green-200">
-                                                承認済み
-                                            </span>
-                                        </div>
-                                        <div class="grid grid-cols-2 md:grid-cols-5 gap-4 text-sm text-notion-gray-600">
-                                            <div>
-                                                <div class="text-xs text-notion-gray-500 mb-1">傷病名</div>
-                                                <div class="font-medium">統合失調症</div>
-                                            </div>
-                                            <div>
-                                                <div class="text-xs text-notion-gray-500 mb-1">年金種類</div>
-                                                <div class="font-medium">基礎年金</div>
-                                            </div>
-                                            <div>
-                                                <div class="text-xs text-notion-gray-500 mb-1">初診日</div>
-                                                <div class="font-medium">2022年3月15日</div>
-                                            </div>
-                                            <div>
-                                                <div class="text-xs text-notion-gray-500 mb-1">家族構成</div>
-                                                <div class="font-medium">配偶者無・子0名</div>
-                                            </div>
-                                            <div>
-                                                <div class="text-xs text-notion-gray-500 mb-1">見込み収益</div>
-                                                <div class="font-medium">250,000円</div>
-                                            </div>
-                                        </div>
-                                        <div class="flex items-center mt-3 text-xs text-notion-gray-500">
-                                            <span>申請日: 2023年8月1日</span>
-                                            <span class="mx-2">•</span>
-                                            <span>担当: 田中一郎</span>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="flex items-center space-x-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
-                                    <button class="p-2 text-notion-gray-500 hover:text-notion-gray-700 hover:bg-notion-gray-100 rounded-lg transition-all duration-200">
-                                        <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-                                            <path d="M10 12a2 2 0 100-4 2 2 0 000 4z"/>
-                                            <path fill-rule="evenodd" d="M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z" clip-rule="evenodd"/>
-                                        </svg>
-                                    </button>
-                                    <button class="p-2 text-notion-gray-500 hover:text-notion-gray-700 hover:bg-notion-gray-100 rounded-lg transition-all duration-200">
-                                        <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-                                            <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"/>
-                                        </svg>
-                                    </button>
-                                </div>
-                            </div>
-                        </a>
-
-                        <!-- Application 3 -->
-                        <a href="project-unified.html?edit=003" class="block bg-white/70 backdrop-blur-sm rounded-xl border border-notion-gray-200/60 shadow-notion hover:shadow-notion-hover transition-all duration-300 p-6 group cursor-pointer">
-                            <div class="flex items-start justify-between">
-                                <div class="flex items-start space-x-4 flex-1">
-                                    <div class="w-12 h-12 bg-gradient-to-br from-purple-400 to-purple-600 rounded-xl flex items-center justify-center text-white font-semibold text-lg">
-                                        佐
-                                    </div>
-                                    <div class="flex-1">
-                                        <div class="flex items-center space-x-3 mb-2">
-                                            <h3 class="text-lg font-semibold text-notion-gray-800">佐藤一郎</h3>
-                                            <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-800 border border-gray-200">
-                                                完了
-                                            </span>
-                                        </div>
-                                        <div class="grid grid-cols-2 md:grid-cols-5 gap-4 text-sm text-notion-gray-600">
-                                            <div>
-                                                <div class="text-xs text-notion-gray-500 mb-1">傷病名</div>
-                                                <div class="font-medium">腰椎椎間板ヘルニア</div>
-                                            </div>
-                                            <div>
-                                                <div class="text-xs text-notion-gray-500 mb-1">年金種類</div>
-                                                <div class="font-medium">共済年金</div>
-                                            </div>
-                                            <div>
-                                                <div class="text-xs text-notion-gray-500 mb-1">初診日</div>
-                                                <div class="font-medium">2021年8月10日</div>
-                                            </div>
-                                            <div>
-                                                <div class="text-xs text-notion-gray-500 mb-1">家族構成</div>
-                                                <div class="font-medium">配偶者有・子3名</div>
-                                            </div>
-                                            <div>
-                                                <div class="text-xs text-notion-gray-500 mb-1">見込み収益</div>
-                                                <div class="font-medium">400,000円</div>
-                                            </div>
-                                        </div>
-                                        <div class="flex items-center mt-3 text-xs text-notion-gray-500">
-                                            <span>申請日: 2023年6月1日</span>
-                                            <span class="mx-2">•</span>
-                                            <span>担当: 山田次郎</span>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="flex items-center space-x-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
-                                    <button class="p-2 text-notion-gray-500 hover:text-notion-gray-700 hover:bg-notion-gray-100 rounded-lg transition-all duration-200">
-                                        <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-                                            <path d="M10 12a2 2 0 100-4 2 2 0 000 4z"/>
-                                            <path fill-rule="evenodd" d="M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z" clip-rule="evenodd"/>
-                                        </svg>
-                                    </button>
-                                    <button class="p-2 text-notion-gray-500 hover:text-notion-gray-700 hover:bg-notion-gray-100 rounded-lg transition-all duration-200">
-                                        <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-                                            <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"/>
-                                        </svg>
-                                    </button>
-                                </div>
-                            </div>
-                        </a>
-
-                        <!-- Application 4 -->
-                        <a href="project-unified.html?edit=004" class="block bg-white/70 backdrop-blur-sm rounded-xl border border-notion-gray-200/60 shadow-notion hover:shadow-notion-hover transition-all duration-300 p-6 group cursor-pointer">
-                            <div class="flex items-start justify-between">
-                                <div class="flex items-start space-x-4 flex-1">
-                                    <div class="w-12 h-12 bg-gradient-to-br from-green-400 to-green-600 rounded-xl flex items-center justify-center text-white font-semibold text-lg">
-                                        鈴
-                                    </div>
-                                    <div class="flex-1">
-                                        <div class="flex items-center space-x-3 mb-2">
-                                            <h3 class="text-lg font-semibold text-notion-gray-800">鈴木美智子</h3>
-                                            <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800 border border-yellow-200">
-                                                申請準備中
-                                            </span>
-                                        </div>
-                                        <div class="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm text-notion-gray-600">
-                                            <div>
-                                                <div class="text-xs text-notion-gray-500 mb-1">傷病名</div>
-                                                <div class="font-medium">双極性障害</div>
-                                            </div>
-                                            <div>
-                                                <div class="text-xs text-notion-gray-500 mb-1">年金種類</div>
-                                                <div class="font-medium">厚生年金</div>
-                                            </div>
-                                            <div>
-                                                <div class="text-xs text-notion-gray-500 mb-1">初診日</div>
-                                                <div class="font-medium">2023年12月1日</div>
-                                            </div>
-                                            <div>
-                                                <div class="text-xs text-notion-gray-500 mb-1">見込み収益</div>
-                                                <div class="font-medium">350,000円</div>
-                                            </div>
-                                        </div>
-                                        <div class="flex items-center mt-3 text-xs text-notion-gray-500">
-                                            <span>作成日: 2023年11月1日</span>
-                                            <span class="mx-2">•</span>
-                                            <span>担当: 佐藤花子</span>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="flex items-center space-x-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
-                                    <button class="p-2 text-notion-gray-500 hover:text-notion-gray-700 hover:bg-notion-gray-100 rounded-lg transition-all duration-200">
-                                        <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-                                            <path d="M10 12a2 2 0 100-4 2 2 0 000 4z"/>
-                                            <path fill-rule="evenodd" d="M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z" clip-rule="evenodd"/>
-                                        </svg>
-                                    </button>
-                                    <button class="p-2 text-notion-gray-500 hover:text-notion-gray-700 hover:bg-notion-gray-100 rounded-lg transition-all duration-200">
-                                        <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-                                            <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"/>
-                                        </svg>
-                                    </button>
-                                </div>
-                            </div>
-                        </a>
+                        <!-- Applications will be dynamically generated by JavaScript -->
                     </div>
                 </div>
             </main>
+        </div>
+    </div>
+
+    <!-- View Application Modal -->
+    <div id="view-modal" class="fixed inset-0 bg-black bg-opacity-50 z-50 hidden flex items-center justify-center">
+        <div class="bg-white rounded-xl shadow-2xl max-w-4xl w-full m-4 max-h-[90vh] overflow-y-auto">
+            <div class="sticky top-0 bg-white px-6 py-4 border-b border-gray-200 rounded-t-xl">
+                <div class="flex items-center justify-between">
+                    <h2 class="text-xl font-semibold text-notion-gray-800">申請詳細</h2>
+                    <button onclick="closeViewModal()" class="p-2 text-notion-gray-500 hover:text-notion-gray-700 hover:bg-notion-gray-100 rounded-lg transition-all duration-200">
+                        <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                            <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"/>
+                        </svg>
+                    </button>
+                </div>
+            </div>
+            <div id="modal-content" class="p-6">
+                <!-- Content will be populated by JavaScript -->
+            </div>
+            <div class="sticky bottom-0 bg-white px-6 py-4 border-t border-gray-200 rounded-b-xl flex justify-end space-x-3">
+                <button onclick="closeViewModal()" class="px-4 py-2.5 text-sm font-medium text-notion-gray-600 border border-notion-gray-300 rounded-lg hover:bg-notion-gray-50 transition-all duration-200">
+                    閉じる
+                </button>
+                <button onclick="editFromModal()" class="px-4 py-2.5 bg-linear-blue-600 hover:bg-linear-blue-700 text-white text-sm font-medium rounded-lg transition-all duration-200 shadow-linear">
+                    編集する
+                </button>
+            </div>
         </div>
     </div>
 </body>


### PR DESCRIPTION
## Summary
- Fixed bug where clicking on application data redirected to new application creation page
- Added dedicated modal dialog for viewing application details with read-only information
- Properly separated "view" and "edit" actions with distinct UI elements

## Changes Made
- **Added view modal**: Created a detailed modal dialog that displays all application information including family composition details
- **Action separation**: Distinguished between view (eye icon) and edit (pencil icon) buttons
- **Dynamic rendering**: Replaced hardcoded HTML cards with JavaScript-generated content from sample data
- **Enhanced UX**: Added modal close functionality via ESC key and outside clicks
- **Family data display**: Improved presentation of spouse and children information in the view modal

## Test Plan
- [x] Click view button (eye icon) opens modal with application details
- [x] Click edit button (pencil icon) redirects to edit form  
- [x] Modal displays all application information correctly
- [x] Family composition shows detailed spouse and children data
- [x] Modal can be closed via close button, ESC key, or clicking outside
- [x] Edit from modal button works correctly
- [x] Search and filter functionality still works

🤖 Generated with [Claude Code](https://claude.ai/code)